### PR TITLE
Fix tests by recreating database tables each time a test is run

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -34,27 +34,15 @@ Base.metadata.create_all(bind=engine)
 
 @pytest.fixture()
 def session():
+    Base.metadata.create_all(bind=engine)
     connection = engine.connect()
-    transaction = connection.begin()
     session = TestingSessionLocal(bind=connection)
-
-    # Begin a nested transaction (using SAVEPOINT).
-    nested = connection.begin_nested()
-
-    # If the application code calls session.commit, it will end the nested
-    # transaction. Need to start a new one when that happens.
-    @sa.event.listens_for(session, "after_transaction_end")
-    def end_savepoint(session, transaction):
-        nonlocal nested
-        if not nested.is_active:
-            nested = connection.begin_nested()
 
     yield session
 
-    # Rollback the overall transaction, restoring the state before the test ran.
     session.close()
-    transaction.rollback()
     connection.close()
+    Base.metadata.drop_all(bind=engine)
 
 
 # A fixture for the fastapi test client which depends on the


### PR DESCRIPTION
Every time we run a test we delete all tables and create them again.

It will be slower than the approach with transactions but it works at least and is less complicated.