### PR TITLE
Secure users get endpoint

### DIFF
--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -24,7 +24,9 @@ async def register(
     return UserQuery().create_user(db, new_user)
 
 
-@router.get("/users", response_model=List[UserObject])
+@router.get(
+    "/users", response_model=List[UserObject], dependencies=[Depends(get_current_user)]
+)
 async def get_users(db=Depends(get_db)):
     users = UserQuery().get_users(db)
     return users

--- a/backend/tests/api/users/test_user.py
+++ b/backend/tests/api/users/test_user.py
@@ -1,3 +1,4 @@
+from fastapi import status
 from queries.user_query import UserQuery
 from tests.conftest import create_user
 
@@ -32,3 +33,12 @@ def test_get_users(session, authorized_client):
     response = authorized_client.get("/users/me")
 
     assert len(response.json()) == 3
+
+
+def test_get_users_unauthorized(session, client):
+    create_user(session, username="John", email="John@gmail.com", id=2)
+    create_user(session, username="Ave", email="Ave@gmail.com", id=3)
+
+    response = client.get("/users/me")
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED


### PR DESCRIPTION
The GET endpoint /users was not secured. It's fixed by adding new a dependancy.