### PR TITLE
Show search settings only if you are logged in

### DIFF
--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -66,6 +66,20 @@ const LoginControl = () => {
   );
 };
 
+const SearchSettings = () => {
+  const accessToken = useContext(UserContext).accessToken;
+
+  if (accessToken) {
+    return (
+      <Link href="/settings">
+        <Button sx={{ my: 1, color: "white", display: "block" }}>
+          Search Settings
+        </Button>
+      </Link>
+    );
+  }
+};
+
 const Header = () => {
   return (
     <AppBar position="static" sx={{ backgroundColor: "#313C56" }}>
@@ -83,13 +97,8 @@ const Header = () => {
                 News
               </Button>
             </Link>
-            <Link href="/settings">
-              <Button sx={{ my: 1, color: "white", display: "block" }}>
-                Search Settings
-              </Button>
-            </Link>
+            <SearchSettings />
           </Box>
-
           <Link href="/profile" style={{ textDecoration: "none" }}>
             <LoginControl />
           </Link>


### PR DESCRIPTION
If the application has an access token then show Serach Settings in header. Otherwise don't show it.